### PR TITLE
fix: null safety warning

### DIFF
--- a/lib/src/provider/flutter_advanced_networkimage.dart
+++ b/lib/src/provider/flutter_advanced_networkimage.dart
@@ -126,7 +126,7 @@ class AdvancedNetworkImage extends ImageProvider<AdvancedNetworkImage> {
     if (memory) {
       cache ??= imageCache;
       final key = await obtainKey(configuration);
-      return cache!.evict(key);
+      return cache.evict(key);
     }
     if (disk) {
       return removeFromCache(url);


### PR DESCRIPTION
### What?
Remove exclamation that was causing a null-safety warning.